### PR TITLE
fix(ci): unblock Dependabot PR checks by updating qs lockfile

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -7484,9 +7484,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
## Summary
- updates server/package-lock.json to use qs@6.14.2
- resolves GHSA-w7fw-mjwx-w883 currently failing CI (
pm audit --omit=dev and OSV scan)

## Validation
- 
pm --prefix server audit --omit=dev -> 0 vulnerabilities
- 
pm --prefix server test -> pass
- 
pm --prefix client test -> pass

## Why this matters
All open Dependabot PRs are currently failing the same shared checks because they run against a merge commit with main. Fixing the vulnerability in main unblocks those PR checks.